### PR TITLE
Update docker_deploy_mmc.md

### DIFF
--- a/manual/deployment/docker_deploy_mmc.md
+++ b/manual/deployment/docker_deploy_mmc.md
@@ -40,7 +40,7 @@ ENVIRONMENT=dev
 DRIVER=~fastapi+~websockets
 HOST=0.0.0.0
 PORT=18002
-ONEBOT_WS_URLS=["ws://napcat:8095"]
+ONEBOT_WS_URLS=["ws://maim-bot-napcat:8095"]
 EOF
 ```
 获取config.py
@@ -55,7 +55,7 @@ vim docker-config/adapters/config.py
 ```
 ```python
 # 修改config.py
-Fastapi_url: str = "http://core:8000/api/message"  # 容器间内部通信
+Fastapi_url: str = "http://maim-bot-core:8000/api/message"  # 容器间内部通信
 ```
 
 ### 2.2 ✏️ 修改env配置
@@ -109,7 +109,7 @@ vim docker-config/mmc/bot_config.toml
 修改通信地址：
 ```toml
 [platforms]
-nonebot-qq = "http://adapters:18002/api/message"  # 使用容器服务名通信
+nonebot-qq = "http://maim-bot-adapters:18002/api/message"  # 使用容器服务名通信
 ```
 
 ---


### PR DESCRIPTION
将`http://core:8000/api/message`等容器名的改为`http://maim-bot-core:8000/api/message`
今天上午自己部署在这卡了一会
新手照抄本文档部署的成功率些许能加一点

## Sourcery 总结

更新部署文档中的容器服务名称，以提高部署的清晰度和准确性

增强功能：
- 修改配置文件，使用更具体的容器服务名称，以提高部署的可靠性

文档：
- 更新 Docker 部署文档，使用正确的容器服务名称进行内部通信

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update container service names in deployment documentation to improve deployment clarity and accuracy

Enhancements:
- Modify configuration files to use more specific container service names for improved deployment reliability

Documentation:
- Update Docker deployment documentation to use correct container service names for internal communication

</details>