### PR TITLE
补充 Docker 镜像拉取速度缓慢解决方案

### DIFF
--- a/manual/deployment/mmc_deploy_linux.md
+++ b/manual/deployment/mmc_deploy_linux.md
@@ -142,7 +142,7 @@ host = "localhost"   # 麦麦在.env文件中设置的主机地址，即HOST字�
 port = 8000          # 麦麦在.env文件中设置的端口，即PORT字段
 ```
 
-## 启动麦麦
+## 七、启动麦麦
 
 ### 启动麦麦核心
 到MaiBot下运行`python3 bot.py`

--- a/manual/deployment/mmc_docker_deploy.md
+++ b/manual/deployment/mmc_docker_deploy.md
@@ -2,6 +2,7 @@
 
 ## 📋 环境要求
 - ✅ 已安装 Docker 环境
+   - 如果没有 Docker 环境，请参考[获取 Docker](https://docs.docker.net.cn/get-started/get-docker/)
 - ⚙️ 最低系统配置：2 核 CPU / 2GB 内存 / 5GB 磁盘空间
 - 🐧 本教程测试环境：Ubuntu Server 24.04 LTS
 
@@ -114,6 +115,41 @@ vim docker-compose.yml
 ```bash
 docker compose up -d && sleep 15 && docker compose down
 ```
+
+:::details Docker 镜像拉取速度缓慢解决方案
+可以通过配置镜像源解决
+- macOS/Windows（使用 Docker Desktop）
+   - 打开 Docker Desktop 程序，点击右上角齿轮图标进入设置
+   - 点击`Docker Engine`，你会看到一个输入框
+   - 在输入框中，填入以下内容：
+   ```json
+   {
+  "registry-mirrors": [
+    "https://docker.1ms.run",
+    "https://docker.1panel.live",
+    "https://docker.ketches.cn"
+     ]
+   }
+   ```
+   注意：如果输入框内没有内容，你可以直接复制以上所有内容并粘贴。但如果输入框内的内容非空，请确保在保留原有内容的基础上，将新的镜像源添加到 `registry-mirrors` 数组中。
+   搞不懂？把以上内容和你原来的`daemon.json`文件内容（就是输入框内的文字）发给AI，让它帮你修改
+   - 修改完成后，点击右下角的`Apply & restart`重启Docker，再次运行`docker compose up -d && sleep 15 && docker compose down`即可
+- Linux（使用命令行）
+   - 在终端中执行以下命令 **（注意：此操作会覆盖`/etc/docker/daemon.json`文件中的现有内容）**
+   ```bash
+   echo '{
+  "registry-mirrors": [
+    "https://docker.1ms.run",
+    "https://docker.1panel.live",
+    "https://docker.ketches.cn"
+     ]
+   }' | sudo tee /etc/docker/daemon.json
+   ```
+   - 重启 Docker 服务以使配置生效
+   ```bash
+   sudo systemctl restart docker
+   ```
+:::
 
 ### 3.2 🔧 调整麦麦配置
 ```bash

--- a/manual/deployment/old/docker_deploy.md
+++ b/manual/deployment/old/docker_deploy.md
@@ -38,6 +38,41 @@ NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker compose up -d
 NAPCAT_UID=$(id -u) NAPCAT_GID=$(id -g) docker-compose up -d
 ```
 
+:::details Docker 镜像拉取速度缓慢解决方案
+可以通过配置镜像源解决
+- macOS/Windows（使用 Docker Desktop）
+   - 打开 Docker Desktop 程序，点击右上角齿轮图标进入设置
+   - 点击`Docker Engine`，你会看到一个输入框
+   - 在输入框中，填入以下内容：
+   ```json
+   {
+  "registry-mirrors": [
+    "https://docker.1ms.run",
+    "https://docker.1panel.live",
+    "https://docker.ketches.cn"
+     ]
+   }
+   ```
+   注意：如果输入框内没有内容，你可以直接复制以上所有内容并粘贴。但如果输入框内的内容非空，请确保在保留原有内容的基础上，将新的镜像源添加到 `registry-mirrors` 数组中。
+   搞不懂？把以上内容和你原来的`daemon.json`文件内容（就是输入框内的文字）发给AI，让它帮你修改
+   - 修改完成后，点击右下角的`Apply & restart`重启Docker，再次运行`docker compose up -d && sleep 15 && docker compose down`即可
+- Linux（使用命令行）
+   - 在终端中执行以下命令 **（注意：此操作会覆盖`/etc/docker/daemon.json`文件中的现有内容）**
+   ```bash
+   echo '{
+  "registry-mirrors": [
+    "https://docker.1ms.run",
+    "https://docker.1panel.live",
+    "https://docker.ketches.cn"
+     ]
+   }' | sudo tee /etc/docker/daemon.json
+   ```
+   - 重启 Docker 服务以使配置生效
+   ```bash
+   sudo systemctl restart docker
+   ```
+:::
+
 
 ### 3. 修改配置并重启Docker
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

添加文档，解释如何配置 Docker 镜像仓库镜像，以提高部署期间拉取镜像的速度。

文档：
- 在 Docker 部署指南中，添加关于在 macOS、Windows 和 Linux 上配置 Docker 镜像仓库镜像的说明。
- 在 Docker 部署指南中，包含指向官方 Docker 安装指南的链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add documentation explaining how to configure Docker registry mirrors to improve image pull speeds during deployment.

Documentation:
- Add instructions for configuring Docker registry mirrors on macOS, Windows, and Linux in the Docker deployment guides.
- Include a link to the official Docker installation guide in the Docker deployment guide.

</details>