### PR TITLE
修正开发文档的content_format

### DIFF
--- a/develop/maim_message/message_base.md
+++ b/develop/maim_message/message_base.md
@@ -105,7 +105,7 @@ class FormatInfo:
     def from_dict(cls, data: Dict) -> "FormatInfo":
 ```
 
-`content_format`: 标记Adapter可以发送的格式信息，**必填**，默认为空，填写告诉MaiBot Core将会接受的格式信息。
+`content_format`: 标记本条消息包含的内容类型，**必填**，默认为空，告诉MaiBot Core此条消息包含的内容的类型。
 
 `accept_format`: 标记Adapter可以接受的格式信息，**必填**，默认为空，告诉MaiBot Core可以发送的格式信息。
 

--- a/develop/plugin_develop/develop_plugin.md
+++ b/develop/plugin_develop/develop_plugin.md
@@ -107,7 +107,7 @@ user_info = UserInfo(
 构造示例：
 ```python
 format_info = FormatInfo(
-    content_format=["text", "image"],  # 可发送的格式
+    content_format=["text", "image"],  # 消息中包含的格式
     accept_format=["text", "image"]   # 可接收的格式
 )
 ```
@@ -238,6 +238,11 @@ def construct_message_to_maimcore(platform_name: str, user_id: int, group_id: in
         Seg("text", text_content),
         # 可以添加其他 Seg, 如 Seg("image", "base64data...")
     ])
+    format_info = {
+        "content_format": ["text"], # 本样例消息中包含了text格式
+        "accept_format": ["text", "image"]
+    }
+    message_info.format_info = format_info
     return MessageBase(message_info=message_info, message_segment=message_segment)
 
 # 6. 运行并发送消息


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新开发者文档，以明确 `content_format` 的含义和用法。

文档：
- 澄清 `content_format` 指示特定消息中包含的内容类型，而不是适配器可以发送的类型。
- 更新插件开发示例，以正确演示如何设置 `content_format`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update developer documentation to clarify the meaning and usage of `content_format`.

Documentation:
- Clarify that `content_format` indicates the content types included in a specific message, not the types the adapter can send.
- Update the plugin development example to correctly demonstrate setting `content_format`.

</details>