### PR TITLE
Linux 文档小修复

### DIFF
--- a/manual/deployment/mmc_deploy_linux.md
+++ b/manual/deployment/mmc_deploy_linux.md
@@ -117,7 +117,12 @@ cp template/template.env .env
 > [!IMPORTANT]
 > 配置示例：
 > ![](/images/napcat_websockets_client.png)
-2. 打开`MaiBot-Napcat-Adapter`文件夹下的`config.toml`，配置`[Napcat_Server]`、`[MaiBot_Server]`、`[Napcat]`字段
+2. 从模版复制配置文件
+```bash
+cd MaiBot-Napcat-Adapter/
+cp template/template_config.toml config.toml
+```
+3. 打开`config.toml`，配置`[Napcat_Server]`、`[MaiBot_Server]`、`[Napcat]`字段
     - `[Napcat_Server]`字段的port,应该与Napcat设置的反向代理的url相同（这里是8095）
     - `[Napcat_Server]`字段的heartbeat,应该与Napcat设置的反向代理的心跳间隔相同（注意，Napcat中的间隔为毫秒，填入时请转化为秒，这里是30）
     - `[MaiBot_Server]`字段的port,应该与麦麦本体的`.env`中的`PORT`相同


### PR DESCRIPTION
`config.toml` 是要自己复制的。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

明确 Linux 部署文档，添加在编辑模板配置文件之前复制该文件的步骤。

文档：
- 在 Linux 部署指南中添加将 `template/template_config.toml` 复制到 `config.toml` 的说明
- 调整步骤编号，以反映在配置字段之前新增的复制步骤

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify Linux deployment documentation by adding a step to copy the template configuration file before editing it.

Documentation:
- Add instructions to copy `template/template_config.toml` to `config.toml` in the Linux deployment guide
- Adjust step numbering to reflect the new copy step before configuring fields

</details>