### PR TITLE
docs: 更新 GoCQ Adapter 文档

### DIFF
--- a/manual/adapters/gocq.md
+++ b/manual/adapters/gocq.md
@@ -1,6 +1,7 @@
 # MaiBot GoCQ Adapter 文档
 
 这个适配器不容易被腾讯制裁！（审阅人：未经广泛测试，一家之言，大家可以试试）
+zhiyucn补充：实际上是因人而异
 
 ## GoCQ 配置
 ### 安装 GoCQ
@@ -54,3 +55,4 @@ python main.py
 ```
 ### 配置 GoCQ Adapter
 此 Go-CQ Adapter基于 Napcat Adapter 二次修改的，配置与其类似，这里就不再赘述。
+注意：Napcat_server项被替换为了gocq_server项

--- a/manual/adapters/gocq.md
+++ b/manual/adapters/gocq.md
@@ -55,4 +55,4 @@ python main.py
 ```
 ### 配置 GoCQ Adapter
 此 Go-CQ Adapter基于 Napcat Adapter 二次修改的，配置与其类似，这里就不再赘述。
-注意：Napcat_server项被替换为了gocq_server项
+警告：与Napcat Adapter不同的是，这里的Napcat_server项在跟进Napcat Adapter的更新后，被替换为了gocq_server项，从旧版本升级到新版本时，一定要注意修改配置。

--- a/manual/adapters/gocq.md
+++ b/manual/adapters/gocq.md
@@ -7,7 +7,7 @@ zhiyucn补充：实际上是因人而异
 ### 安装 GoCQ
 首先，你需要安装 GoCQ 本身，以下列出了一些不同的GoCQ版本：  
 [AstralGocq](https://github.com/ProtocolScience/AstralGocq)  
-[gocq-http(New)](https://github.com/LagrangeDev/go-cqhttp)
+[gocq-http(New)](https://github.com/LagrangeDev/go-cqhttp)  
 在这些项目中的release页面下载对应的版本，这里只提供Windows版本的安装教程。  
 
 ### 配置GoCQ

--- a/manual/adapters/index.md
+++ b/manual/adapters/index.md
@@ -8,5 +8,6 @@ Hi!👋 欢迎来到麦麦的 Adapters 文档中心。
 
 ## 适配器列表
 - [Napcat Adapter](./napcat)
+- [Gocq Adapter](./gocq)
 - [MaiBot TTS Adapter](./tts/)
 - 微信Adapter

--- a/manual/deployment/mmc_deploy_docker.md
+++ b/manual/deployment/mmc_deploy_docker.md
@@ -8,7 +8,7 @@
 ---
 
 ::: warning
-**升级到0.6.2时由于跟换了adapter需要重新拉取docker-compose.yml和adapter相关配置(adapter配置方法见[修改相关配置](#⚙%EF%B8%8F-二、麦麦环境配置))，  
+**升级到0.6.2时由于更换了adapter需要重新拉取docker-compose.yml和adapter相关配置(adapter配置方法见[修改相关配置](#⚙%EF%B8%8F-二、麦麦环境配置))，  
 新版的adapter需要将napcat改为客户端([配置示例](#_5-2-⚙%EF%B8%8F-napcat配置入口))**
 :::
 


### PR DESCRIPTION
增加了关于腾讯制裁的补充说明，并修正了 GoCQ Adapter 的配置示例，将 Napcat_server 替换为了 gocq_server。 增加了 GoCQ Adapter 在适配器列表中的链接。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新 GoCQ 适配器文档，以提供关于腾讯制裁的更多背景信息，更正配置示例，将适配器添加到索引，并修复 Docker 部署指南中的拼写错误。

文档：
- 增加一条注释，说明对腾讯制裁的抵抗程度可能因用户而异。
- 在 GoCQ 适配器文档中，将 Napcat_server 配置键替换为 gocq_server。
- 在适配器索引中添加指向 GoCQ 适配器的链接。
- 在 Docker 部署升级说明中，将 “跟换” 更正为 “更换”，修复拼写错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GoCQ Adapter documentation to provide additional context on Tencent sanctions, correct configuration examples, add the adapter to the index, and fix a typo in the Docker deployment guide.

Documentation:
- Add a note clarifying that resistance to Tencent sanctions may vary by user.
- Replace the Napcat_server configuration key with gocq_server in the GoCQ Adapter doc.
- Add a link to the GoCQ Adapter in the adapters index.
- Fix a typo by changing “跟换” to “更换” in the Docker deployment upgrade instructions.

</details>