### PR TITLE
Update mmc_deploy_android.md

### DIFF
--- a/manual/deployment/mmc_deploy_android.md
+++ b/manual/deployment/mmc_deploy_android.md
@@ -53,7 +53,7 @@ proot-distro login ubuntu     # 登录Ubuntu
 
 ```bash
 apt update
-apt install sudo vim git python3-dev python3.12-venv build-essential screen curl
+apt install sudo vim git python3-dev python3.12-venv build-essential screen curl python3-pip
 ```
 
 ### 用户账户配置 (可选但推荐)


### PR DESCRIPTION
添加了 python3-pip 的安装，至于为什么加，请看VCR
<img width="1080" height="586" alt="Screenshot_2025_0719_220401" src="https://github.com/user-attachments/assets/97922d45-05e6-4a0c-94fd-ee8accc87006" />

## Sourcery 总结

文档:
- 在 Android 部署手册的 `apt install` 命令中包含 `python3-pip`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Include python3-pip in the apt install command for the Android deployment manual

</details>