### PR TITLE
Fix wrong url in config.mts

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -195,7 +195,7 @@ export default defineConfig({
             { text: 'Manifest系统指南', link: '/develop/plugin_develop/manifest-guide' },
             { text: 'Actions系统', link: '/develop/plugin_develop/action-components' },
             { text: '命令处理系统', link: '/develop/plugin_develop/command-components' },
-            { text: '工具系统', link: '/develop/plugin_develop/command-components' },
+            { text: '工具系统', link: '/develop/plugin_develop/tool-components' },
             { text: '配置管理指南', link: '/develop/plugin_develop/configuration-guide' },
             { text: '依赖管理', link: '/develop/plugin_develop/dependency-management' },
             { text: 'API参考',


### PR DESCRIPTION
抓虫
tool指向的链接是command

## Sourcery 摘要

错误修复：
- 修复“工具系统”入口的导航 URL，使其指向 `/develop/plugin_develop/tool-components` 而非错误的路径

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the navigation URL for the Tool System entry to point to /develop/plugin_develop/tool-components instead of the incorrect path

</details>